### PR TITLE
Add serverId option to ItemImageGenerator

### DIFF
--- a/itemImageFramesGenerator.html
+++ b/itemImageFramesGenerator.html
@@ -30,6 +30,7 @@ Force enable extended sprites: <input type="checkbox" id="forceEnableExtendedSpr
 with this feature enabled)<br/>
 Enable transparency: <input type="checkbox" id="enableTransparency"/> (OTC feature 'GameSpritesAlphaChannel')<br/>
 Use .dat item IDs as image IDs: <input type="checkbox" id="useDatItemIdsAsImageIds"/> (no 'items.otb' required)<br/>
+Start generating at item server id: <input type="number" id="itemServerIdStartGeneration" value="0"/> (Will skip the items before the input id)<br/>
 <br/>
 <button id="loadFiles">LOAD FILES</button>
 <br/>

--- a/itemImageGenerator.html
+++ b/itemImageGenerator.html
@@ -25,6 +25,7 @@ Force enable extended sprites: <input type="checkbox" id="forceEnableExtendedSpr
 with this feature enabled)<br/>
 Enable transparency: <input type="checkbox" id="enableTransparency"/> (OTC feature 'GameSpritesAlphaChannel')<br/>
 Use .dat item IDs as image IDs: <input type="checkbox" id="useDatItemIdsAsImageIds"/> (no 'items.otb' required)<br/>
+Start generating at item server id: <input type="number" id="itemServerIdStartGeneration" value="0"/> (Will skip the items before the input id)<br/>
 <br/>
 <button id="loadFiles">LOAD FILES</button>
 <br/>

--- a/itemImageGenerator.ts
+++ b/itemImageGenerator.ts
@@ -12,9 +12,11 @@ class ItemImageGenerator extends WebsiteImageGeneratorBase {
     private forceEnableExtendedSpritesCheckbox: HTMLInputElement;
     private enableTransparencyCheckbox: HTMLInputElement;
     private useDatItemIdsAsImageIdsCheckbox: HTMLInputElement;
+    private itemServerIdStartGenerationInput: HTMLInputElement;
 
     private onlyPickable = true;
     private useDatItemIdsAsImageIds = false;
+    private itemServerIdStartGenerationValue = 0;
 
     init() {
         super.init();
@@ -22,6 +24,7 @@ class ItemImageGenerator extends WebsiteImageGeneratorBase {
         this.forceEnableExtendedSpritesCheckbox = <HTMLInputElement>document.getElementById('forceEnableExtendedSprites');
         this.enableTransparencyCheckbox = <HTMLInputElement>document.getElementById('enableTransparency');
         this.useDatItemIdsAsImageIdsCheckbox = <HTMLInputElement>document.getElementById('useDatItemIdsAsImageIds');
+        this.itemServerIdStartGenerationInput = <HTMLInputElement>document.getElementById('itemServerIdStartGeneration');
     }
 
     afterSetClientVersion() {
@@ -32,12 +35,14 @@ class ItemImageGenerator extends WebsiteImageGeneratorBase {
             this.client.enableFeature(GameFeature.GameSpritesAlphaChannel);
         }
         this.otbRequired = !this.useDatItemIdsAsImageIdsCheckbox.checked;
+
+        this.itemServerIdStartGenerationValue = parseInt(this.itemServerIdStartGenerationInput.value);
     }
 
     startImageGenerator(imageGenerator: ImageGenerator, otbManager: OtbManager, datManager: DatManager, spriteManager: SpriteManager, zip) {
         this.onlyPickable = this.onlyPickableCheckbox.checked;
         this.useDatItemIdsAsImageIds = this.useDatItemIdsAsImageIdsCheckbox.checked;
-        this.generateItemImage(imageGenerator, zip, 0);
+        this.generateItemImage(imageGenerator, zip, this.itemServerIdStartGenerationValue);
     }
 
     generateItemImage(imageGenerator: ImageGenerator, zip, serverId: number) {


### PR DESCRIPTION
- itemServerIdStartGenerationInput  was null if I didnt include that in ItemImageFramgesGenerator

This PR adds an option to start generation at certain id, in order to not waste time generating once again the thousands of ids