### PR TITLE
fix: outfit images white pixels transparency

### DIFF
--- a/tools/colored-outfit-images-generator/libs/outfitter.php
+++ b/tools/colored-outfit-images-generator/libs/outfitter.php
@@ -3,7 +3,7 @@
  * @author Kamil Karkus <kaker@wp.eu>
  * @author Gesior.pl <phoowned@wp.pl>
  * @copyright Copyright (c) 2012, Kamil Karkus
- * @version 4 - fixed rendering with invalid parameters
+ * @version 5 - fixed white pixels transparency
  */
 
 class Outfitter {
@@ -61,7 +61,7 @@ class Outfitter {
     ];
 
 	public static $data = [];
-	private static $transparentBackgroundColor = array(255, 255, 255);
+	private static $transparentBackgroundColor = array(255, 255, 255, 127);
 	public static $outfitPath;
 	public static $resizeAllOutfitsTo64px = false;
 
@@ -143,7 +143,8 @@ class Outfitter {
                 $image_template = imagecreatefrompng(self::$outfitPath . $outfit . '/' . $animation . '_' . $mountState . '_1_' . $direction . '_template.png');
             } else {
                 $image_template = imagecreatetruecolor(imagesx($image_outfit), imagesy($image_outfit));
-                $bgcolor = imagecolorallocate($image_template, self::$transparentBackgroundColor[0], self::$transparentBackgroundColor[1], self::$transparentBackgroundColor[2]);
+                $bgcolor = imagecolorallocatealpha($image_template, self::$transparentBackgroundColor[0], self::$transparentBackgroundColor[1], self::$transparentBackgroundColor[2], self::$transparentBackgroundColor[3]);
+                imagefill($image_template, 0, 0, $bgcolor);
                 imagecolortransparent($image_template, $bgcolor);
 
                 imagealphablending($image_template, false);
@@ -199,7 +200,7 @@ class Outfitter {
 		} else {
 			$image_outfitT = imagecreatetruecolor($width, $height);
 		}
-		imagefill($image_outfitT, 0, 0, $bgcolor = imagecolorallocate($image_outfitT, self::$transparentBackgroundColor[0], self::$transparentBackgroundColor[1], self::$transparentBackgroundColor[2]));
+		imagefill($image_outfitT, 0, 0, $bgcolor = imagecolorallocatealpha($image_outfitT, self::$transparentBackgroundColor[0], self::$transparentBackgroundColor[1], self::$transparentBackgroundColor[2], self::$transparentBackgroundColor[3]));
 
 		imagecopyresampled($image_outfitT, $image_outfit, imagesx($image_outfitT)-$width, imagesy($image_outfitT)-$height, 0, 0, $width, $height, $width, $height);
 


### PR DESCRIPTION
If outfit has full white pixels (no shadow) and you try to render outfit with white color, these pixels will be transparent, because image transparency color is set to `255, 255, 255` (white, 0% transparency).

After fix, transparency color is set to `255, 255, 255, 127` (white, 50% transparency), so it cannot conflict with any outfit color, as all outfit pixels have 0% transparency.

Before and after comparison on website with brown background:
<img width="584" height="386" alt="image" src="https://github.com/user-attachments/assets/0891cfd2-1e20-4cb3-a95f-3b09c4283f7d" />
